### PR TITLE
Changed the result bar to scale better

### DIFF
--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -6,12 +6,14 @@ window.fetch('api/pollen')
     return Promise.reject(response.statusText)
   })
   .then((result) => {
+    // An abitrary value to make the bar scale better
+    const maxPollenCount = 200
     document.getElementById('animation-container').style.display = 'none'
     var resultContainer = document.getElementById('result-container')
     resultContainer.style.cssText = ''
     var resultBar = resultContainer.querySelector('.bar')
     resultBar.style.cssText = 'animation: bar 1.5s ease;'
-    resultBar.style.setProperty('--bar-height', `${result * 2}px`)
+    resultBar.style.setProperty('--bar-height', `${result / maxPollenCount * 100}%`)
     var pollenValueElement = resultContainer.querySelector('.pollen-value')
     pollenValueElement.innerHTML = Math.round(result * 100) / 100
   })

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -58,7 +58,7 @@ body {
     position: relative;
 
     .bar {
-      --bar-height: 0px;
+      --bar-height: 0%;
       height: var(--bar-height);
       width: 100%;
       display: flex;


### PR DESCRIPTION
The result bar used to show the amount of pollen predicted used to have its height set to twice the pollen value in px. Eg. for a pollen count of 30 the bar would be `60px` high.
This didn't really scale all that well as higher numbers would seem really small.
Now we use a percentage of 200 (An arbitrarily high number based on anecdotal statistics 👨‍🔬📈) so that high numbers seem high and exceptionally high numbers may explode outside of the viewport 🚀