### PR TITLE
Greater distinction between environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ _The pollen count of the future, today!_
 2. Create a `.env` file and fill out the following:
    * `PREDICTOR_URL` : The url for the pollen prediction service
    * `API_KEY` : The API key for the pollen prediction service
-   * `ENVIRONMENT` : The environment that this webservice runs in eg. `development`
+   * `NODE_ENV` : The environment that this webservice runs in. Valid values are:
+     * `'development'`
+     * `'production'`
 3. Test using `npm test`
 4. Run using `npm start`
 

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const express = require('express')
 const path = require('path')
 

--- a/app.js
+++ b/app.js
@@ -25,6 +25,7 @@ app.use(sassMiddleware({
   src: path.join(__dirname, 'public'),
   dest: path.join(__dirname, 'public'),
   indentedSyntax: false, // true = .sass and false = .scss
+  outputStyle: app.get('env') === 'development' ? 'nested' : 'compressed',
   sourceMap: true
 }))
 app.use(compression())

--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ const path = require('path')
 
 // Middleware
 const createError = require('http-errors')
-const logger = require('morgan')
 const sassMiddleware = require('node-sass-middleware')
 const compression = require('compression')
 
@@ -18,7 +17,6 @@ const app = express()
 app.set('views', path.join(__dirname, 'views'))
 app.set('view engine', 'pug')
 
-app.use(logger('dev'))
 app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use(sassMiddleware({
@@ -29,6 +27,11 @@ app.use(sassMiddleware({
   sourceMap: true
 }))
 app.use(compression())
+
+if (app.get('env') === 'development') {
+  const logger = require('morgan')
+  app.use(logger('dev'))
+}
 
 app.use(express.static(path.join(__dirname, 'public')))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -2163,6 +2164,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "dev": true,
       "requires": {
         "basic-auth": "~2.0.0",
         "debug": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "dotenv": "^6.0.0",
     "express": "~4.16.0",
     "http-errors": "~1.6.2",
-    "morgan": "~1.9.0",
     "node-sass-middleware": "0.11.0",
     "pug": "2.0.0-beta11",
     "request-promise-native": "^1.0.5"
   },
   "devDependencies": {
+    "morgan": "^1.9.0",
     "standard": "^11.0.1"
   },
   "description": "The pollen count of the future, today!",

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const request = require('request-promise-native')
 const router = express.Router()
-require('dotenv').config()
 const API_KEY = process.env.API_KEY
 const PREDICTOR_URL = process.env.PREDICTOR_URL
 


### PR DESCRIPTION
I've refactored the project to have more of a difference between `development` and `production` environments:

* Moved `require('dotenv')` from routes/api.js to app.js where it makes more sense to have
* Corrected wrong information about specifying environment in the `README` file
* The Sass middleware now compresses the output if not in `development` environment
* The Morgan logging middleware is now only used in `development` environment