### PR TITLE
Added a special case for 0 pollen in index.js

### DIFF
--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -15,7 +15,11 @@ window.fetch('api/pollen')
     resultBar.style.cssText = 'animation: bar 1.5s ease;'
     resultBar.style.setProperty('--bar-height', `${result / maxPollenCount * 100}%`)
     var pollenValueElement = resultContainer.querySelector('.pollen-value')
-    pollenValueElement.innerHTML = Math.round(result * 100) / 100
+    if (result <= 1) {
+      pollenValueElement.innerHTML = `${String.fromCodePoint('0X1F44C')}<br>All Clear`
+    } else {
+      pollenValueElement.innerHTML = Math.round(result * 100) / 100
+    }
   })
   .catch((error) => {
     console.error(error)


### PR DESCRIPTION
In light of the grass pollen season finally coming to an end I thought we should prepare for months of 0 responses from the predictor. Hence I have introduced handling of the 0 case which will present the 👌 emoji along with the text: `All Clear`.
I'm not sure whether we should just test a really low value instead of *exactly* 0.
Something to consider would also be to introduce different randomly selected texts to spice up the site outside of the season (though probably only seen right before and after the season).