### PR TITLE
update short name (#10)

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
     "name": "Tomorrow's Pollen Today",
-    "short_name": "Tomorrow's Pollen",
+    "short_name": "PollenOutlook",
     "icons": [
         {
             "src": "/public/images/icon/android-chrome-192x192.png",


### PR DESCRIPTION
I updated to "PollenOutlook". I can always add a space if you think it's not going to be removed.

Another idea is to write tomorrow as 2morrow but I am not sure it looks that great, eg:
2morrow'sPollen