### PR TITLE
Updated to use the new Yesterday's Pollen API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 
 1. Install dependencies with `npm install`
 2. Create a `.env` file and fill out the following:
-   * `PREDICTOR_URL` : The url for the pollen prediction service
-   * `API_KEY` : The API key for the pollen prediction service
+   * `'YESTERDAYS_POLLEN_URL'` : The url for the server running [Yesterday's Pollen Today](https://github.com/Tomorrows-pollen-today/yesterdays-pollen-today/)
    * `NODE_ENV` : The environment that this webservice runs in. Valid values are:
      * `'development'`
      * `'production'`

--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ if (app.get('env') === 'development') {
 
 app.use(express.static(path.join(__dirname, 'public')))
 
-app.use('/', indexRouter)
+app.use('/', require('./middleware/pollenTypes'), indexRouter)
 app.use('/api', apiRouter)
 
 // catch 404 and forward to error handler

--- a/middleware/pollenTypes.js
+++ b/middleware/pollenTypes.js
@@ -1,0 +1,18 @@
+const request = require('request-promise-native')
+
+async function getPollenTypes () {
+  try {
+    return await request({
+      method: 'GET',
+      uri: `${process.env.YESTERDAYS_POLLEN_URL}/api/pollentype`,
+      json: true
+    })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+module.exports = async function (req, res, next) {
+  res.locals.pollenTypes = await getPollenTypes()
+  next()
+}

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -1,23 +1,28 @@
-fetchPollen(0, 0)
-  .then((result) => {
-    // An abitrary value to make the bar scale better
-    const maxPollenCount = 200
-    document.getElementById('animation-container').style.display = 'none'
-    var resultContainer = document.getElementById('result-container')
-    resultContainer.style.cssText = ''
-    var resultBar = resultContainer.querySelector('.bar')
-    resultBar.style.cssText = 'animation: bar 1.5s ease;'
-    resultBar.style.setProperty('--bar-height', `${result.predictedPollenCount / maxPollenCount * 100}%`)
-    var pollenValueElement = resultContainer.querySelector('.pollen-value')
-    if (result.predictedPollenCount <= 1) {
-      pollenValueElement.innerHTML = `${String.fromCodePoint('0X1F44C')}<br>All Clear`
-    } else {
-      pollenValueElement.innerHTML = Math.round(result.predictedPollenCount * 100) / 100
-    }
-  })
-  .catch((error) => {
-    console.error(error)
-  })
+const chartContainerElements = document.getElementsByClassName('chart-container')
+
+for (let chartContainerElement of chartContainerElements) {
+  fetchPollen(chartContainerElement.getAttribute('data-pollen-type'), 0)
+    .then((result) => {
+      // An abitrary value to make the bar scale better
+      const maxPollenCount = 200
+      chartContainerElement.querySelector('.animation-container').style.display = 'none'
+      var resultContainer = chartContainerElement.querySelector('.result-container')
+      resultContainer.style.cssText = ''
+      var resultBar = resultContainer.querySelector('.bar')
+      resultBar.style.cssText = 'animation: bar 1.5s ease;'
+      resultBar.style.setProperty('--bar-height', `${result.predictedPollenCount / maxPollenCount * 100}%`)
+      var pollenValueElement = resultContainer.querySelector('.pollen-value')
+      pollenValueElement.style.cssText = 'animation: rise-text 1.5s ease;'
+      if (result.predictedPollenCount <= 1) {
+        pollenValueElement.innerHTML = `${String.fromCodePoint('0X1F44C')}<br>All Clear`
+      } else {
+        pollenValueElement.innerHTML = Math.round(result.predictedPollenCount * 100) / 100
+      }
+    })
+    .catch((error) => {
+      console.error(error)
+    })
+}
 
 /**
  * Fetches the predicted pollen count for tomorrow for the given pollen type and location.

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -1,16 +1,4 @@
-let requestUrl = new URL(window.location)
-requestUrl.pathname = '/api/pollen'
-requestUrl.search = new URLSearchParams({
-  pollenType: 1,
-  location: 0
-})
-window.fetch(requestUrl)
-  .then((response) => {
-    if (response.ok) {
-      return response.json()
-    }
-    return Promise.reject(response.statusText)
-  })
+fetchPollen(0, 0)
   .then((result) => {
     // An abitrary value to make the bar scale better
     const maxPollenCount = 200
@@ -30,3 +18,24 @@ window.fetch(requestUrl)
   .catch((error) => {
     console.error(error)
   })
+
+/**
+ * Fetches the predicted pollen count for tomorrow for the given pollen type and location.
+ * @param  {number} pollenType The type of pollen to get a prediction for.
+ * @param  {number} location   The location to get a prediction for.
+ * @return {Promise}           A promise object that is resolved with an object containing the predicted
+ *                             pollen count as well as the location.
+ */
+async function fetchPollen (pollenType, location) {
+  let requestUrl = new URL(window.location)
+  requestUrl.pathname = '/api/pollen'
+  requestUrl.search = new URLSearchParams({
+    pollenType: pollenType,
+    location: location
+  })
+  let response = await window.fetch(requestUrl)
+  if (response.ok) {
+    return response.json()
+  }
+  return Promise.reject(response.statusText)
+}

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -1,10 +1,10 @@
+// An abitrary value to make the bar scale better
+const maxPollenCount = 200
 const chartContainerElements = document.getElementsByClassName('chart-container')
 
 for (let chartContainerElement of chartContainerElements) {
   fetchPollen(chartContainerElement.getAttribute('data-pollen-type'), 0)
     .then((result) => {
-      // An abitrary value to make the bar scale better
-      const maxPollenCount = 200
       chartContainerElement.querySelector('.animation-container').style.display = 'none'
       var resultContainer = chartContainerElement.querySelector('.result-container')
       resultContainer.style.cssText = ''

--- a/public/javascript/index.js
+++ b/public/javascript/index.js
@@ -1,4 +1,10 @@
-window.fetch('api/pollen')
+let requestUrl = new URL(window.location)
+requestUrl.pathname = '/api/pollen'
+requestUrl.search = new URLSearchParams({
+  pollenType: 1,
+  location: 0
+})
+window.fetch(requestUrl)
   .then((response) => {
     if (response.ok) {
       return response.json()
@@ -13,12 +19,12 @@ window.fetch('api/pollen')
     resultContainer.style.cssText = ''
     var resultBar = resultContainer.querySelector('.bar')
     resultBar.style.cssText = 'animation: bar 1.5s ease;'
-    resultBar.style.setProperty('--bar-height', `${result / maxPollenCount * 100}%`)
+    resultBar.style.setProperty('--bar-height', `${result.predictedPollenCount / maxPollenCount * 100}%`)
     var pollenValueElement = resultContainer.querySelector('.pollen-value')
-    if (result <= 1) {
+    if (result.predictedPollenCount <= 1) {
       pollenValueElement.innerHTML = `${String.fromCodePoint('0X1F44C')}<br>All Clear`
     } else {
-      pollenValueElement.innerHTML = Math.round(result * 100) / 100
+      pollenValueElement.innerHTML = Math.round(result.predictedPollenCount * 100) / 100
     }
   })
   .catch((error) => {

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -19,11 +19,7 @@ body {
 }
 
 .chart-container {
-  height: 60%;
-
-  @media (min-width: 768px) {
-    height: 70%;
-  }
+  height: 100%;
 
   .bar {
     background-color: $chart-color;

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -18,6 +18,16 @@ body {
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
 }
 
+.charts-container {
+  display: flex;
+  height: 70%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0 10px 5vw;
+}
+
 .chart-container {
   height: 100%;
 

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -22,7 +22,7 @@ body {
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
 }
 
-#chart-container {
+.chart-container {
   height: 60%;
 
   @media (min-width: 768px) {
@@ -33,7 +33,7 @@ body {
     background-color: $chart-color;
   }
 
-  #animation-container {
+  .animation-container {
     display: flex;
     flex-direction: row;
     align-items: flex-end;
@@ -50,7 +50,7 @@ body {
     }
   }
 
-  #result-container {
+  .result-container {
     height: 100%;
     width: 100%;
     display: flex;

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -84,6 +84,11 @@ body {
       width: 100%;
     }
   }
+
+  .pollen-name {
+    font-size: 4vw;
+    text-align: center;
+  }
 }
 
 @keyframes rise {

--- a/public/stylesheets/style.scss
+++ b/public/stylesheets/style.scss
@@ -4,12 +4,8 @@ $title-color: #E7E5DF;
 
 #title {
   color: $title-color;
-  font-size: 3em;
+  font-size: 5vw;
   text-align: center;
-
-  @media (min-width: 768px) {
-    font-size: 5rem;
-  }
 }
 
 html, body {
@@ -76,7 +72,7 @@ body {
     }
 
     .pollen-value {
-      font-size: 3em;
+      font-size: 5vw;
       position: absolute;
       text-align: center;
       width: 100%;
@@ -95,9 +91,9 @@ body {
 
 @keyframes rise-text {
   0% {
-    font-size: 0;
+    font-size: 0vw;
   }
   100% {
-    font-size: 3em;
+    font-size: 5vw;
   }
 }

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,12 +3,20 @@ const request = require('request-promise-native')
 const router = express.Router()
 
 router.get('/pollen', async function (req, res, next) {
+  if (!req.query.pollenType || !req.query.location) {
+    return res.sendStatus(400)
+  }
+
   var date = new Date()
   date.setDate(date.getDate() + 1)
   var options = {
     method: 'GET',
     uri: `${process.env.YESTERDAYS_POLLEN_URL}/api/pollen/${date.toISOString()}`,
-    json: true
+    json: true,
+    qs: {
+      pollentype: req.query.pollenType,
+      location: req.query.location
+    }
   }
   var result
   try {
@@ -18,7 +26,11 @@ router.get('/pollen', async function (req, res, next) {
     res.status(500).send('Unable to retrieve pollen numbers.')
   }
   if (result) {
-    res.json(result.PredictedPollenCount)
+    res.json({
+      predictedPollenCount: result.PredictedPollenCount,
+      city: result.Location.City,
+      country: result.Location.Country
+    })
   }
 })
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,22 +1,13 @@
 const express = require('express')
 const request = require('request-promise-native')
 const router = express.Router()
-const API_KEY = process.env.API_KEY
-const PREDICTOR_URL = process.env.PREDICTOR_URL
 
 router.get('/pollen', async function (req, res, next) {
+  var date = new Date()
+  date.setDate(date.getDate() + 1)
   var options = {
-    method: 'POST',
-    uri: PREDICTOR_URL,
-    headers: {
-      Authorization: `Bearer ${API_KEY}`,
-      Accept: 'application/json'
-    },
-    body: {
-      GlobalParameters: {
-        'Output_name': ''
-      }
-    },
+    method: 'GET',
+    uri: `${process.env.YESTERDAYS_POLLEN_URL}/api/pollen/${date.toISOString()}`,
     json: true
   }
   var result
@@ -27,7 +18,7 @@ router.get('/pollen', async function (req, res, next) {
     res.status(500).send('Unable to retrieve pollen numbers.')
   }
   if (result) {
-    res.send(result.Results.predicted_pollen_count.value.Values[0][0])
+    res.json(result.PredictedPollenCount)
   }
 })
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -3,11 +3,11 @@ extends layout
 block content
   #title-container
     h1#title #{title}
-  #chart-container
-    #result-container(style=('display:none;'))
+  .chart-container
+    .result-container(style=('display:none;'))
       .bar
       .pollen-value
-    #animation-container
+    .animation-container
       - var n = 0;
       while n < 8
         .bar.animated-bar

--- a/views/index.pug
+++ b/views/index.pug
@@ -14,6 +14,7 @@ block content
           while n < 8
             .bar.animated-bar
             - n++;
+        .pollen-name=pollenType.name
 
   script(async src='/javascript/randomChart.js')
   script(async src='/javascript/index.js')

--- a/views/index.pug
+++ b/views/index.pug
@@ -3,15 +3,17 @@ extends layout
 block content
   #title-container
     h1#title #{title}
-  .chart-container
-    .result-container(style=('display:none;'))
-      .bar
-      .pollen-value
-    .animation-container
-      - var n = 0;
-      while n < 8
-        .bar.animated-bar
-        - n++;
+  .charts-container
+    for pollenType in pollenTypes
+      .chart-container(data-pollen-type=`${pollenType.pollenid}` style=`width:${100/pollenTypes.length}%;`)
+        div(class='result-container' style=('display:none;'))
+          .bar
+          .pollen-value
+        .animation-container
+          - var n = 0;
+          while n < 8
+            .bar.animated-bar
+            - n++;
 
   script(async src='/javascript/randomChart.js')
   script(async src='/javascript/index.js')


### PR DESCRIPTION
Several changes have been introduced to accomodate the changes introduced in [#4](https://github.com/Tomorrows-pollen-today/yesterdays-pollen-today/pull/4) of [Yesterday's Pollen](https://github.com/Tomorrows-pollen-today/yesterdays-pollen-today/).

* `routes/api.js` has been updated to take pollentype and location as query parameters
* `routes/api.js` has been updated to call the `/api/pollen/{date}?pollentype={pollentype}&location={location}` endpoint of Yesterday's Pollen
* Added `middleware/pollenTypes.js`
* `public/javascript/index.js` has been updated to find all elements with a `data-pollen-type` attribute and fetch pollen numbers for that type
* Updated `views/index.pug` to render chart elements for each type of pollen
* Updated `views/index.pug` and `public/stylesheets/style.scss` to be capable of displaying multiple pollen types.